### PR TITLE
style: constrain tag list icon size to 16px

### DIFF
--- a/themes/default/screen.css
+++ b/themes/default/screen.css
@@ -106,6 +106,12 @@
     padding-bottom: 12px;
     padding-left: 5px;
 }
+.nag-tags-related img,
+.nag-tags-browsing img {
+    width: 16px;
+    height: 16px;
+    vertical-align: middle;
+}
 
 .horde-tags li a img {
     padding-left: 5px;


### PR DESCRIPTION
Lucide icons are 48px PNGs; without explicit dimensions they
render oversized in the tag browsing/related sections.

See also horde/base#89