### PR TITLE
fix(nag): parse ICU date formats when saving tasks

### DIFF
--- a/lib/Nag.php
+++ b/lib/Nag.php
@@ -2,6 +2,7 @@
 
 use Horde\Util\Util;
 use Horde\Date\Format;
+use Horde\Date\Formatter\IcuFormatter;
 
 /**
  * Nag Base Class.
@@ -168,6 +169,36 @@ class Nag
      */
     public static function parseDate($date, $withtime = true)
     {
+        $date = trim($date);
+        $dateFormat = $GLOBALS['prefs']->getValue('date_format_mini');
+        $locale = $GLOBALS['language'] ?? ($GLOBALS['prefs']->getValue('language') ?? 'en_US');
+
+        if (!Format::isStrftimeFormat($dateFormat)) {
+            try {
+                $formatter = new IcuFormatter();
+                if ($withtime && preg_match('/^(.+?)\s+(\S+)$/', $date, $parts)) {
+                    $datePart = $formatter->parse($parts[1], $dateFormat, $locale);
+                    $timeFormat = $GLOBALS['prefs']->getValue('twentyFour') ? 'HH:mm' : 'h:mm a';
+                    $timePart = $formatter->parse($parts[2], $timeFormat, $locale);
+
+                    return new Horde_Date(
+                        ['year'  => (int) $datePart->format('Y'),
+                            'month' => (int) $datePart->format('n'),
+                            'mday'  => (int) $datePart->format('j'),
+                            'hour'  => (int) $timePart->format('G'),
+                            'min'   => (int) $timePart->format('i'),
+                            'sec'   => 0]
+                    );
+                }
+
+                $parsed = $formatter->parse($date, $dateFormat, $locale);
+
+                return new Horde_Date($parsed->getTimestamp());
+            } catch (Exception $e) {
+                // Fall through to legacy parsing.
+            }
+        }
+
         // strptime() is not available on Windows.
         if (!function_exists('strptime')) {
             return new Horde_Date($date);
@@ -176,7 +207,7 @@ class Nag
         // strptime() is locale dependent, i.e. %p is not always matching
         // AM/PM. Set the locale to C to workaround this, but grab the
         // locale's D_FMT before that.
-        $format = $GLOBALS['prefs']->getValue('date_format_mini');
+        $format = $dateFormat;
         if ($withtime) {
             $format .= ' '
                 . ($GLOBALS['prefs']->getValue('twentyFour') ? '%H:%M' : '%I:%M %p');


### PR DESCRIPTION
## Parse ICU date formats when saving NAG tasks
### Summary
Fixes saving tasks when date_format_mini uses ICU patterns (including the default short), which display correctly but were not parsed on submit.
The due-date form shows values via Format::formatDate() (e.g. 23.05.26 08:34 in de_DE), while Nag::parseDate() still called strptime() with the same preference. strptime() only accepts strftime specifiers, so parsing failed and fell back to new Horde_Date($date), which PHP DateTime also rejects for locale-specific strings.
For non-strftime formats, parseDate() now uses IcuFormatter with the user locale. Date and time are parsed separately when both are present, because ICU shortcuts like short cannot be combined with a custom time pattern in one IntlDateFormatter.
Legacy strftime date_format_mini values continue to use the existing strptime() path unchanged.

### Test plan

 Set Horde language to German and date_format_mini to abbreviated / short; create or edit a task with due date 23.05.26 and time 08:34; save — no Zeitformat … nicht erkannt error and due date persists correctly.

 Repeat with 12-hour time (twentyFour off) and a due time like 8:34 AM.

 Save a task with due date only (no time) and with “No due date” selected.

 If an account still has a legacy strftime date_format_mini (e.g. %d.%m.%Y), confirm saving still works.

 Edit recurrence end date (NagRecurrence, withtime = false) with a locale-formatted date string.