### PR TITLE
Refactor/active sync

### DIFF
--- a/config/prefs.php
+++ b/config/prefs.php
@@ -312,21 +312,20 @@ $_prefs['sync_lists'] = [
             $sync[] = $default;
             $GLOBALS['prefs']->setValue('sync_lists', serialize($sync));
         }
-        if ($GLOBALS['conf']['activesync']['enabled'] && !$GLOBALS['prefs']->getValue('activesync_no_multiplex')) {
+        if ($GLOBALS['conf']['activesync']['enabled']
+            && $GLOBALS['prefs']->getValue('activesync_no_multiplex')) {
             try {
-                $sm = $GLOBALS['injector']->getInstance('Horde_ActiveSyncState');
-                $sm->setLogger($GLOBALS['injector']->getInstance('Horde_Log_Logger'));
-                $devices = $sm->listDevices($GLOBALS['registry']->getAuth());
-                foreach ($devices as $device) {
-                    $sm->removeState([
-                        'devId' => $device['device_id'],
-                        'id' => Horde_Core_ActiveSync_Driver::TASKS_FOLDER_UID,
-                        'user' => $GLOBALS['registry']->getAuth(),
-                    ]);
-                }
-                $GLOBALS['notification']->push(_("All state removed for your ActiveSync devices. They will resynchronize next time they connect to the server."));
+                Nag::pruneActiveSyncTaskCache();
+                Nag::touchActiveSyncDeviceCaches();
+                $GLOBALS['notification']->push(
+                    _("Task list sync preferences were saved. Your device will update task list folders on the next folder sync."),
+                    'horde.message'
+                );
             } catch (Horde_ActiveSync_Exception $e) {
-                $GLOBALS['notification']->push(_("There was an error communicating with the ActiveSync server: %s"), $e->getMessage(), 'horde.error');
+                $GLOBALS['notification']->push(
+                    sprintf(_("There was an error communicating with the ActiveSync server: %s"), $e->getMessage()),
+                    'horde.error'
+                );
             }
         }
     },

--- a/lib/Api.php
+++ b/lib/Api.php
@@ -161,7 +161,6 @@ class Nag_Api extends Horde_Registry_Api
             true,
             !empty($params['synchronize'])
         );
-        Nag::persistPrefs();
 
         return $tasklist->getName();
     }
@@ -273,7 +272,6 @@ class Nag_Api extends Horde_Registry_Api
     {
         $tasklist = $GLOBALS['nag_shares']->getShare($id);
         Nag::deleteTasklist($tasklist);
-        Nag::persistPrefs();
     }
 
     /**

--- a/lib/Api.php
+++ b/lib/Api.php
@@ -156,14 +156,14 @@ class Nag_Api extends Horde_Registry_Api
      */
     public function addTasklist($name, $description = '', $color = '', array $params = [])
     {
-        $tasklist = Nag::addTasklist(['name' => $name, 'description' => $description, 'color' => $color]);
+        $tasklist = Nag::addTasklist(
+            ['name' => $name, 'description' => $description, 'color' => $color],
+            true,
+            !empty($params['synchronize'])
+        );
+        Nag::persistPrefs();
 
-        $name = $tasklist->getName();
-        if (!empty($params['synchronize'])) {
-            Nag::addTasklistToSyncLists($name);
-        }
-
-        return $name;
+        return $tasklist->getName();
     }
 
     /**
@@ -272,7 +272,8 @@ class Nag_Api extends Horde_Registry_Api
     public function deleteTasklist($id)
     {
         $tasklist = $GLOBALS['nag_shares']->getShare($id);
-        return Nag::deleteTasklist($tasklist);
+        Nag::deleteTasklist($tasklist);
+        Nag::persistPrefs();
     }
 
     /**

--- a/lib/Api.php
+++ b/lib/Api.php
@@ -160,9 +160,7 @@ class Nag_Api extends Horde_Registry_Api
 
         $name = $tasklist->getName();
         if (!empty($params['synchronize'])) {
-            $sync = @unserialize($GLOBALS['prefs']->getValue('sync_lists'));
-            $sync[] = $name;
-            $GLOBALS['prefs']->setValue('sync_lists', serialize($sync));
+            Nag::addTasklistToSyncLists($name);
         }
 
         return $name;

--- a/lib/Form/CreateTaskList.php
+++ b/lib/Form/CreateTaskList.php
@@ -46,6 +46,9 @@ class Nag_Form_CreateTaskList extends Horde_Form
             $info[$key] = $this->_vars->get($key);
         }
 
-        return Nag::addTasklist($info);
+        $tasklist = Nag::addTasklist($info);
+        Nag::addTasklistToSyncLists($tasklist->getName());
+
+        return $tasklist;
     }
 }

--- a/lib/Form/CreateTaskList.php
+++ b/lib/Form/CreateTaskList.php
@@ -46,9 +46,6 @@ class Nag_Form_CreateTaskList extends Horde_Form
             $info[$key] = $this->_vars->get($key);
         }
 
-        $tasklist = Nag::addTasklist($info);
-        Nag::addTasklistToSyncLists($tasklist->getName());
-
-        return $tasklist;
+        return Nag::addTasklist($info, true, true);
     }
 }

--- a/lib/Nag.php
+++ b/lib/Nag.php
@@ -621,6 +621,9 @@ class Nag
         }
         if ($sync) {
             self::addTasklistToSyncLists($tasklist->getName());
+            self::notifyActiveSyncOfTaskListChange();
+        } elseif ($display) {
+            self::persistPrefs();
         }
 
         return $tasklist;
@@ -659,6 +662,8 @@ class Nag
         } catch (Horde_Share_Exception $e) {
             throw new Nag_Exception(sprintf(_("Unable to save task list \"%s\": %s"), $info['name'], $e->getMessage()));
         }
+
+        self::notifyActiveSyncOfTaskListChange();
     }
 
     /**
@@ -691,7 +696,11 @@ class Nag
             throw new Nag_Exception($e);
         }
 
-        self::removeActiveSyncTaskListFromDeviceCache($tasklist->getName());
+        // Do not remove folder/collection mappings from the device cache here.
+        // The iPhone may still PING/SYNC that folder until FolderSync delivers
+        // FolderHierarchy:Remove. notifyActiveSyncOfTaskListChange() only
+        // invalidates hierarchy; FolderSync diffs foldersync state vs getFolderList().
+        self::notifyActiveSyncOfTaskListChange();
     }
 
     /**
@@ -1797,6 +1806,145 @@ class Nag
     }
 
     /**
+     * Persist task list prefs and wake ActiveSync after web-side list changes.
+     *
+     * Folder hierarchy updates are delivered on the device's next FolderSync
+     * (there is no server push for new folders). This writes sync_lists to the
+     * database immediately and marks device caches so the next SYNC returns
+     * FolderSync required (status 12).
+     *
+     * Stored foldersync state in the database is left intact. Clearing it
+     * causes a synckey mismatch that makes Horde wipe the entire device folder
+     * cache and breaks ongoing PING/SYNC.
+     *
+     * @return boolean  True if at least one device was notified.
+     *
+     * @throws Horde_ActiveSync_Exception
+     */
+    public static function notifyActiveSyncOfTaskListChange()
+    {
+        if (!self::_isActiveSyncEnabled()) {
+            return false;
+        }
+
+        self::persistPrefs();
+
+        if (!empty($GLOBALS['nag_shares'])) {
+            $GLOBALS['nag_shares']->expireListCache();
+        }
+
+        // Do not prune the device folder cache here. Pruning removed entries
+        // before FolderSync breaks PING on those folder ids (status 132). Cache
+        // cleanup for manual sync_lists changes stays in config/prefs.php
+        // on_change; FolderSync Remove updates cache after the device applies it.
+        $updated = self::requestActiveSyncFolderHierarchySync();
+
+        if ($updated
+            && $GLOBALS['registry']->getApp() === 'nag'
+            && !empty($GLOBALS['notification'])) {
+            $GLOBALS['notification']->push(
+                _("Task list change saved. Your device will update task list folders on the next sync."),
+                'horde.message'
+            );
+        }
+
+        return $updated;
+    }
+
+    /**
+     * Tell all of a user's devices to run FolderSync on the next request.
+     *
+     * Clears only the hierarchy synckey in the device cache (same approach as
+     * Horde_ActiveSync_State when invalidating foldersync). Folder entries and
+     * collection synckeys in the cache are kept so PING still resolves folder
+     * ids and Add/Remove diffs in stored foldersync state still work.
+     *
+     * @return boolean  True if at least one device cache was updated.
+     *
+     * @throws Horde_ActiveSync_Exception
+     */
+    public static function requestActiveSyncFolderHierarchySync()
+    {
+        if (!self::_isActiveSyncEnabled()
+            || !$GLOBALS['prefs']->getValue('activesync_no_multiplex')) {
+            return false;
+        }
+
+        $devices = self::_listActiveSyncDevicesForUser();
+        if (!count($devices)) {
+            return false;
+        }
+
+        $sm = $GLOBALS['injector']->getInstance('Horde_ActiveSyncState');
+        $logger = $GLOBALS['injector']->getInstance('Horde_Log_Logger');
+        $sm->setLogger($logger);
+
+        $updated = false;
+        foreach ($devices as $device) {
+            $cache = new Horde_ActiveSync_SyncCache(
+                $sm,
+                $device['device_id'],
+                $device['device_user'],
+                $logger
+            );
+            if (!count($cache->getFolders()) && !count($cache->getCollections(false))) {
+                continue;
+            }
+
+            $cache->hierarchy = '0';
+            $cache->updateTimestamp();
+            $cache->save();
+            $updated = true;
+        }
+
+        return $updated;
+    }
+
+    /**
+     * @return boolean
+     */
+    protected static function _isActiveSyncEnabled()
+    {
+        return !empty($GLOBALS['conf']['activesync']['enabled']);
+    }
+
+    /**
+     * List ActiveSync devices for the logged-in user.
+     *
+     * Tries both the Horde auth id and the original login id so device rows
+     * registered under either form are found.
+     *
+     * @return array  Device rows from Horde_ActiveSync_State::listDevices().
+     *
+     * @throws Horde_ActiveSync_Exception
+     */
+    protected static function _listActiveSyncDevicesForUser()
+    {
+        $registry = $GLOBALS['registry'];
+        $userIds = array_unique(array_filter([
+            $registry->getAuth(),
+            $registry->getAuth('original'),
+        ]));
+        if (!count($userIds)) {
+            return [];
+        }
+
+        $sm = $GLOBALS['injector']->getInstance('Horde_ActiveSyncState');
+        $logger = $GLOBALS['injector']->getInstance('Horde_Log_Logger');
+        $sm->setLogger($logger);
+
+        $devices = [];
+        foreach ($userIds as $userId) {
+            foreach ($sm->listDevices($userId) as $device) {
+                $key = $device['device_id'] . "\0" . $device['device_user'];
+                $devices[$key] = $device;
+            }
+        }
+
+        return array_values($devices);
+    }
+
+    /**
      * Add a task list to the display_tasklists preference.
      *
      * @param string $tasklistId  Task list share id.
@@ -1857,10 +2005,10 @@ class Nag
     /**
      * Remove one task list from per-device ActiveSync caches.
      *
-     * Used when a list is deleted. Only the matching folder/collection entries
-     * are removed so other task folders keep their synckeys for PING. During
-     * FolderDelete, ActiveSync also calls deleteFolderFromHierarchy() for the
-     * hierarchy uid after the backend delete returns.
+     * Not used for web-side deletes (see deleteTasklist()). Intended for
+     * exceptional cleanup; normal list removal is delivered via FolderSync
+     * after requestActiveSyncFolderHierarchySync(). During FolderDelete,
+     * ActiveSync also calls deleteFolderFromHierarchy() for the hierarchy uid.
      *
      * @param string $tasklistId  Task list share id.
      *
@@ -1870,13 +2018,8 @@ class Nag
      */
     public static function removeActiveSyncTaskListFromDeviceCache($tasklistId)
     {
-        if (empty($GLOBALS['conf']['activesync']['enabled'])
+        if (!self::_isActiveSyncEnabled()
             || !$GLOBALS['prefs']->getValue('activesync_no_multiplex')) {
-            return false;
-        }
-
-        $user = $GLOBALS['registry']->getAuth();
-        if (!$user) {
             return false;
         }
 
@@ -1884,14 +2027,19 @@ class Nag
         $sm = $GLOBALS['injector']->getInstance('Horde_ActiveSyncState');
         $logger = $GLOBALS['injector']->getInstance('Horde_Log_Logger');
         $sm->setLogger($logger);
-        $devices = $sm->listDevices($user);
+        $devices = self::_listActiveSyncDevicesForUser();
         if (!count($devices)) {
             return false;
         }
 
         $updated = false;
         foreach ($devices as $device) {
-            $cache = new Horde_ActiveSync_SyncCache($sm, $device['device_id'], $user, $logger);
+            $cache = new Horde_ActiveSync_SyncCache(
+                $sm,
+                $device['device_id'],
+                $device['device_user'],
+                $logger
+            );
             $deviceUpdated = false;
 
             foreach ($cache->getFolders() as $clientUid => $folder) {
@@ -1942,18 +2090,13 @@ class Nag
      */
     public static function pruneActiveSyncTaskCache(array $allowedShareIds = null)
     {
-        if (empty($GLOBALS['conf']['activesync']['enabled'])
+        if (!self::_isActiveSyncEnabled()
             || !$GLOBALS['prefs']->getValue('activesync_no_multiplex')) {
             return false;
         }
 
-        $user = $GLOBALS['registry']->getAuth();
-        if (!$user) {
-            return false;
-        }
-
         if ($allowedShareIds === null) {
-            $allowedShareIds = array_keys(self::getSyncLists());
+            $allowedShareIds = array_values(self::getSyncLists());
         }
 
         $allowed = [];
@@ -1964,7 +2107,7 @@ class Nag
         $sm = $GLOBALS['injector']->getInstance('Horde_ActiveSyncState');
         $logger = $GLOBALS['injector']->getInstance('Horde_Log_Logger');
         $sm->setLogger($logger);
-        $devices = $sm->listDevices($user);
+        $devices = self::_listActiveSyncDevicesForUser();
         if (!count($devices)) {
             return false;
         }
@@ -1972,6 +2115,7 @@ class Nag
         $updated = false;
         foreach ($devices as $device) {
             $devId = $device['device_id'];
+            $user = $device['device_user'];
             $cache = new Horde_ActiveSync_SyncCache($sm, $devId, $user, $logger);
             if (!count($cache->getFolders())) {
                 continue;
@@ -2021,19 +2165,14 @@ class Nag
      */
     public static function touchActiveSyncDeviceCaches()
     {
-        if (empty($GLOBALS['conf']['activesync']['enabled'])) {
-            return false;
-        }
-
-        $user = $GLOBALS['registry']->getAuth();
-        if (!$user) {
+        if (!self::_isActiveSyncEnabled()) {
             return false;
         }
 
         $sm = $GLOBALS['injector']->getInstance('Horde_ActiveSyncState');
         $logger = $GLOBALS['injector']->getInstance('Horde_Log_Logger');
         $sm->setLogger($logger);
-        $devices = $sm->listDevices($user);
+        $devices = self::_listActiveSyncDevicesForUser();
         if (!count($devices)) {
             return false;
         }
@@ -2042,7 +2181,7 @@ class Nag
             $cache = new Horde_ActiveSync_SyncCache(
                 $sm,
                 $device['device_id'],
-                $user,
+                $device['device_user'],
                 $logger
             );
             $cache->updateTimestamp();

--- a/lib/Nag.php
+++ b/lib/Nag.php
@@ -590,9 +590,8 @@ class Nag
      *
      * @return Horde_Share  The new share.
      *
-     * Note: Does not update the sync_lists preference. Web-created lists are
-     * opt-in for ActiveSync via Nag preferences; EAS-created lists use
-     * Nag_Api::addTasklist() with synchronize => true.
+     * Note: Does not update sync_lists itself. The create-task-list form and
+     * Nag_Api::addTasklist() with synchronize => true call addTasklistToSyncLists().
      */
     public static function addTasklist(array $info, $display = true)
     {
@@ -678,6 +677,8 @@ class Nag
             throw new Horde_Exception_PermissionDenied(_("You are not allowed to delete this task list."));
         }
 
+        self::removeTasklistFromSyncLists($tasklist->getName());
+
         // Delete the task list.
         $storage = &$GLOBALS['injector']->getInstance('Nag_Factory_Driver')->create($tasklist->getName());
         $result = $storage->deleteAll();
@@ -688,6 +689,9 @@ class Nag
         } catch (Horde_Share_Exception $e) {
             throw new Nag_Exception($e);
         }
+
+        self::pruneActiveSyncTaskCache();
+        self::touchActiveSyncDeviceCaches();
     }
 
     /**
@@ -1756,6 +1760,173 @@ class Nag
             $owner = $share->get('name');
         }
         return $owner;
+    }
+
+    /**
+     * Add a task list to the sync_lists preference.
+     *
+     * @param string $tasklistId  Task list share id.
+     */
+    public static function addTasklistToSyncLists($tasklistId)
+    {
+        $sync = @unserialize($GLOBALS['prefs']->getValue('sync_lists'));
+        if (!is_array($sync)) {
+            $sync = [];
+        }
+        if (in_array($tasklistId, $sync, true)) {
+            return;
+        }
+
+        $sync[] = $tasklistId;
+        $GLOBALS['prefs']->setValue('sync_lists', serialize(array_values($sync)));
+    }
+
+    /**
+     * Drop cached task folder/collection mappings that are no longer synced.
+     *
+     * FolderSync state in storage is kept so the next client FolderSync can
+     * diff and emit FolderHierarchy:Remove. Pruning stale cache entries causes
+     * PING on those folders to fail with FolderGone, which prompts clients to
+     * run FolderSync (status FolderSync required).
+     *
+     * @param array|null $allowedShareIds  Share ids that may remain cached;
+     *                                     defaults to current getSyncLists().
+     *
+     * @return boolean  True if at least one device cache was updated.
+     *
+     * @throws Horde_ActiveSync_Exception
+     */
+    public static function pruneActiveSyncTaskCache(array $allowedShareIds = null)
+    {
+        if (empty($GLOBALS['conf']['activesync']['enabled'])
+            || !$GLOBALS['prefs']->getValue('activesync_no_multiplex')) {
+            return false;
+        }
+
+        $user = $GLOBALS['registry']->getAuth();
+        if (!$user) {
+            return false;
+        }
+
+        if ($allowedShareIds === null) {
+            $allowedShareIds = array_keys(self::getSyncLists());
+        }
+
+        $allowed = [];
+        foreach ($allowedShareIds as $tasklistId) {
+            $allowed[Horde_ActiveSync::CLASS_TASKS . ':' . $tasklistId] = true;
+        }
+
+        $sm = $GLOBALS['injector']->getInstance('Horde_ActiveSyncState');
+        $logger = $GLOBALS['injector']->getInstance('Horde_Log_Logger');
+        $sm->setLogger($logger);
+        $devices = $sm->listDevices($user);
+        if (!count($devices)) {
+            return false;
+        }
+
+        $updated = false;
+        foreach ($devices as $device) {
+            $devId = $device['device_id'];
+            $cache = new Horde_ActiveSync_SyncCache($sm, $devId, $user, $logger);
+            if (!count($cache->getFolders())) {
+                continue;
+            }
+
+            $deviceUpdated = false;
+            foreach ($cache->getFolders() as $clientUid => $folder) {
+                if (($folder['class'] ?? '') !== Horde_ActiveSync::CLASS_TASKS) {
+                    continue;
+                }
+                $backendId = $folder['serverid'] ?? '';
+                if (empty($backendId) || !isset($allowed[$backendId])) {
+                    $cache->deleteFolder($clientUid);
+                    $deviceUpdated = true;
+                }
+            }
+
+            foreach ($cache->getCollections(false) as $collectionId => $collection) {
+                if (($collection['class'] ?? '') !== Horde_ActiveSync::CLASS_TASKS) {
+                    continue;
+                }
+                $backendId = $collection['serverid'] ?? '';
+                if (empty($backendId) && isset($cache->getFolders()[$collectionId]['serverid'])) {
+                    $backendId = $cache->getFolders()[$collectionId]['serverid'];
+                }
+                if (empty($backendId) || !isset($allowed[$backendId])) {
+                    $cache->removeCollection($collectionId, true);
+                    $deviceUpdated = true;
+                }
+            }
+
+            if ($deviceUpdated) {
+                $cache->save();
+                $updated = true;
+            }
+        }
+
+        return $updated;
+    }
+
+    /**
+     * Bump the ActiveSync cache timestamp on all devices for the current user.
+     *
+     * @return boolean  True if at least one device cache was touched.
+     *
+     * @throws Horde_ActiveSync_Exception
+     */
+    public static function touchActiveSyncDeviceCaches()
+    {
+        if (empty($GLOBALS['conf']['activesync']['enabled'])) {
+            return false;
+        }
+
+        $user = $GLOBALS['registry']->getAuth();
+        if (!$user) {
+            return false;
+        }
+
+        $sm = $GLOBALS['injector']->getInstance('Horde_ActiveSyncState');
+        $logger = $GLOBALS['injector']->getInstance('Horde_Log_Logger');
+        $sm->setLogger($logger);
+        $devices = $sm->listDevices($user);
+        if (!count($devices)) {
+            return false;
+        }
+
+        foreach ($devices as $device) {
+            $cache = new Horde_ActiveSync_SyncCache(
+                $sm,
+                $device['device_id'],
+                $user,
+                $logger
+            );
+            $cache->updateTimestamp();
+            $cache->save();
+        }
+
+        return true;
+    }
+
+    /**
+     * Remove a task list from the sync_lists preference (no UI notification).
+     *
+     * @param string $tasklistId  Task list share id.
+     */
+    public static function removeTasklistFromSyncLists($tasklistId)
+    {
+        $sync = @unserialize($GLOBALS['prefs']->getValue('sync_lists'));
+        if (!is_array($sync)) {
+            return;
+        }
+
+        $key = array_search($tasklistId, $sync);
+        if ($key === false) {
+            return;
+        }
+
+        unset($sync[$key]);
+        $GLOBALS['prefs']->setValue('sync_lists', serialize(array_values($sync)));
     }
 
     /**

--- a/lib/Nag.php
+++ b/lib/Nag.php
@@ -586,14 +586,12 @@ class Nag
      * Creates a new share.
      *
      * @param array $info       Hash with tasklist information.
-     * @param boolean $display  Add the new tasklist to display_tasklists
+     * @param boolean $display  Add the new tasklist to display_tasklists.
+     * @param boolean $sync     Add the new tasklist to sync_lists (ActiveSync).
      *
      * @return Horde_Share  The new share.
-     *
-     * Note: Does not update sync_lists itself. The create-task-list form and
-     * Nag_Api::addTasklist() with synchronize => true call addTasklistToSyncLists().
      */
-    public static function addTasklist(array $info, $display = true)
+    public static function addTasklist(array $info, $display = true, $sync = false)
     {
         try {
             $tasklist = $GLOBALS['nag_shares']->newShare(
@@ -619,8 +617,10 @@ class Nag
         }
 
         if ($display) {
-            $GLOBALS['display_tasklists'][] = $tasklist->getName();
-            $GLOBALS['prefs']->setValue('display_tasklists', serialize($GLOBALS['display_tasklists']));
+            self::addTasklistToDisplayListsPref($tasklist->getName());
+        }
+        if ($sync) {
+            self::addTasklistToSyncLists($tasklist->getName());
         }
 
         return $tasklist;
@@ -677,6 +677,7 @@ class Nag
             throw new Horde_Exception_PermissionDenied(_("You are not allowed to delete this task list."));
         }
 
+        self::removeTasklistFromDisplayListsPref($tasklist->getName());
         self::removeTasklistFromSyncLists($tasklist->getName());
 
         // Delete the task list.
@@ -690,8 +691,7 @@ class Nag
             throw new Nag_Exception($e);
         }
 
-        self::pruneActiveSyncTaskCache();
-        self::touchActiveSyncDeviceCaches();
+        self::removeActiveSyncTaskListFromDeviceCache($tasklist->getName());
     }
 
     /**
@@ -995,10 +995,12 @@ class Nag
             $_SERVER['REQUEST_TIME'] = time();
         }
 
+        self::refreshWebSessionState();
+
         // Update the preference for what task lists to display. If the user
         // doesn't have any selected task lists for view then fall back to
         // some available list.
-        $GLOBALS['display_tasklists'] = @unserialize($GLOBALS['prefs']->getValue('display_tasklists'));
+        $GLOBALS['display_tasklists'] = self::_getPrefList('display_tasklists');
         if (!$GLOBALS['display_tasklists']) {
             $GLOBALS['display_tasklists'] = [];
         }
@@ -1763,31 +1765,173 @@ class Nag
     }
 
     /**
+     * Reload Nag state that is cached in the web PHP session.
+     *
+     * ActiveSync (and other clients) update the database in their own requests;
+     * the browser session may still hold stale Horde_Prefs and Horde_Share list
+     * caches until logout.
+     */
+    public static function refreshWebSessionState()
+    {
+        if ($GLOBALS['registry']->getApp() !== 'nag') {
+            return;
+        }
+
+        $GLOBALS['prefs']->cleanup();
+        $GLOBALS['prefs']->retrieve();
+
+        if (!empty($GLOBALS['nag_shares'])) {
+            $GLOBALS['nag_shares']->expireListCache();
+        }
+    }
+
+    /**
+     * Write preference changes to storage immediately.
+     *
+     * ActiveSync requests use a separate PHP session; the web UI may otherwise
+     * read stale values from the session prefs cache until reload.
+     */
+    public static function persistPrefs()
+    {
+        $GLOBALS['prefs']->store();
+    }
+
+    /**
+     * Add a task list to the display_tasklists preference.
+     *
+     * @param string $tasklistId  Task list share id.
+     */
+    public static function addTasklistToDisplayListsPref($tasklistId)
+    {
+        $display = self::_getPrefList('display_tasklists');
+        if (in_array($tasklistId, $display, true)) {
+            return;
+        }
+
+        $display[] = $tasklistId;
+        self::_setPrefList('display_tasklists', $display);
+        $GLOBALS['display_tasklists'] = $display;
+    }
+
+    /**
+     * Remove a task list from the display_tasklists preference.
+     *
+     * @param string $tasklistId  Task list share id.
+     */
+    public static function removeTasklistFromDisplayListsPref($tasklistId)
+    {
+        $display = self::_getPrefList('display_tasklists');
+        $key = array_search($tasklistId, $display, true);
+        if ($key === false) {
+            return;
+        }
+
+        unset($display[$key]);
+        $display = array_values($display);
+        self::_setPrefList('display_tasklists', $display);
+        if (isset($GLOBALS['display_tasklists']) && is_array($GLOBALS['display_tasklists'])) {
+            $gkey = array_search($tasklistId, $GLOBALS['display_tasklists'], true);
+            if ($gkey !== false) {
+                unset($GLOBALS['display_tasklists'][$gkey]);
+                $GLOBALS['display_tasklists'] = array_values($GLOBALS['display_tasklists']);
+            }
+        }
+    }
+
+    /**
      * Add a task list to the sync_lists preference.
      *
      * @param string $tasklistId  Task list share id.
      */
     public static function addTasklistToSyncLists($tasklistId)
     {
-        $sync = @unserialize($GLOBALS['prefs']->getValue('sync_lists'));
-        if (!is_array($sync)) {
-            $sync = [];
-        }
+        $sync = self::_getPrefList('sync_lists');
         if (in_array($tasklistId, $sync, true)) {
             return;
         }
 
         $sync[] = $tasklistId;
-        $GLOBALS['prefs']->setValue('sync_lists', serialize(array_values($sync)));
+        self::_setPrefList('sync_lists', $sync);
+    }
+
+    /**
+     * Remove one task list from per-device ActiveSync caches.
+     *
+     * Used when a list is deleted. Only the matching folder/collection entries
+     * are removed so other task folders keep their synckeys for PING. During
+     * FolderDelete, ActiveSync also calls deleteFolderFromHierarchy() for the
+     * hierarchy uid after the backend delete returns.
+     *
+     * @param string $tasklistId  Task list share id.
+     *
+     * @return boolean  True if at least one device cache was updated.
+     *
+     * @throws Horde_ActiveSync_Exception
+     */
+    public static function removeActiveSyncTaskListFromDeviceCache($tasklistId)
+    {
+        if (empty($GLOBALS['conf']['activesync']['enabled'])
+            || !$GLOBALS['prefs']->getValue('activesync_no_multiplex')) {
+            return false;
+        }
+
+        $user = $GLOBALS['registry']->getAuth();
+        if (!$user) {
+            return false;
+        }
+
+        $backendId = Horde_ActiveSync::CLASS_TASKS . ':' . $tasklistId;
+        $sm = $GLOBALS['injector']->getInstance('Horde_ActiveSyncState');
+        $logger = $GLOBALS['injector']->getInstance('Horde_Log_Logger');
+        $sm->setLogger($logger);
+        $devices = $sm->listDevices($user);
+        if (!count($devices)) {
+            return false;
+        }
+
+        $updated = false;
+        foreach ($devices as $device) {
+            $cache = new Horde_ActiveSync_SyncCache($sm, $device['device_id'], $user, $logger);
+            $deviceUpdated = false;
+
+            foreach ($cache->getFolders() as $clientUid => $folder) {
+                if (($folder['class'] ?? '') !== Horde_ActiveSync::CLASS_TASKS) {
+                    continue;
+                }
+                if (($folder['serverid'] ?? '') === $backendId) {
+                    $cache->deleteFolder($clientUid);
+                    $deviceUpdated = true;
+                }
+            }
+
+            foreach ($cache->getCollections(false) as $collectionId => $collection) {
+                if (($collection['class'] ?? '') !== Horde_ActiveSync::CLASS_TASKS) {
+                    continue;
+                }
+                $collBackendId = $collection['serverid'] ?? '';
+                if ($collBackendId === $backendId
+                    || $collectionId === $backendId
+                    || $collectionId === $tasklistId) {
+                    $cache->removeCollection($collectionId, true);
+                    $deviceUpdated = true;
+                }
+            }
+
+            if ($deviceUpdated) {
+                $cache->save();
+                $updated = true;
+            }
+        }
+
+        return $updated;
     }
 
     /**
      * Drop cached task folder/collection mappings that are no longer synced.
      *
+     * Intended for sync_lists preference changes, not for single list deletes.
      * FolderSync state in storage is kept so the next client FolderSync can
-     * diff and emit FolderHierarchy:Remove. Pruning stale cache entries causes
-     * PING on those folders to fail with FolderGone, which prompts clients to
-     * run FolderSync (status FolderSync required).
+     * diff and emit FolderHierarchy:Remove.
      *
      * @param array|null $allowedShareIds  Share ids that may remain cached;
      *                                     defaults to current getSyncLists().
@@ -1915,18 +2059,35 @@ class Nag
      */
     public static function removeTasklistFromSyncLists($tasklistId)
     {
-        $sync = @unserialize($GLOBALS['prefs']->getValue('sync_lists'));
-        if (!is_array($sync)) {
-            return;
-        }
-
-        $key = array_search($tasklistId, $sync);
+        $sync = self::_getPrefList('sync_lists');
+        $key = array_search($tasklistId, $sync, true);
         if ($key === false) {
             return;
         }
 
         unset($sync[$key]);
-        $GLOBALS['prefs']->setValue('sync_lists', serialize(array_values($sync)));
+        self::_setPrefList('sync_lists', array_values($sync));
+    }
+
+    /**
+     * @param string $pref  Preference name.
+     *
+     * @return array  List of share ids.
+     */
+    protected static function _getPrefList($pref)
+    {
+        $list = @unserialize($GLOBALS['prefs']->getValue($pref));
+
+        return is_array($list) ? array_values($list) : [];
+    }
+
+    /**
+     * @param string $pref  Preference name.
+     * @param array  $list  List of share ids.
+     */
+    protected static function _setPrefList($pref, array $list)
+    {
+        $GLOBALS['prefs']->setValue($pref, serialize(array_values($list)));
     }
 
     /**

--- a/lib/Nag.php
+++ b/lib/Nag.php
@@ -696,10 +696,9 @@ class Nag
             throw new Nag_Exception($e);
         }
 
-        // Do not remove folder/collection mappings from the device cache here.
-        // The iPhone may still PING/SYNC that folder until FolderSync delivers
-        // FolderHierarchy:Remove. notifyActiveSyncOfTaskListChange() only
-        // invalidates hierarchy; FolderSync diffs foldersync state vs getFolderList().
+        // Drop collection/PING state only; keep folder cache entries so FolderSync
+        // can still emit FolderHierarchy:Remove for this list's client folder id.
+        self::removeActiveSyncTaskListCollectionsFromDeviceCache($tasklist->getName());
         self::notifyActiveSyncOfTaskListChange();
     }
 
@@ -2003,7 +2002,51 @@ class Nag
     }
 
     /**
-     * Remove one task list from per-device ActiveSync caches.
+     * Remove per-device SYNC/PING collection entries for one task list.
+     *
+     * Folder cache mappings are kept so FolderSync can still deliver
+     * FolderHierarchy:Remove after a web-side delete.
+     *
+     * @param string $tasklistId  Task list share id.
+     *
+     * @return boolean  True if at least one device cache was updated.
+     *
+     * @throws Horde_ActiveSync_Exception
+     */
+    public static function removeActiveSyncTaskListCollectionsFromDeviceCache($tasklistId)
+    {
+        if (!self::_isActiveSyncEnabled()
+            || !$GLOBALS['prefs']->getValue('activesync_no_multiplex')) {
+            return false;
+        }
+
+        $sm = $GLOBALS['injector']->getInstance('Horde_ActiveSyncState');
+        $logger = $GLOBALS['injector']->getInstance('Horde_Log_Logger');
+        $sm->setLogger($logger);
+        $devices = self::_listActiveSyncDevicesForUser();
+        if (!count($devices)) {
+            return false;
+        }
+
+        $updated = false;
+        foreach ($devices as $device) {
+            $cache = new Horde_ActiveSync_SyncCache(
+                $sm,
+                $device['device_id'],
+                $device['device_user'],
+                $logger
+            );
+            if (self::_purgeActiveSyncTaskListCollections($cache, $tasklistId)) {
+                $cache->save();
+                $updated = true;
+            }
+        }
+
+        return $updated;
+    }
+
+    /**
+     * Remove one task list from per-device ActiveSync caches (folders and collections).
      *
      * Not used for web-side deletes (see deleteTasklist()). Intended for
      * exceptional cleanup; normal list removal is delivered via FolderSync
@@ -2052,21 +2095,41 @@ class Nag
                 }
             }
 
-            foreach ($cache->getCollections(false) as $collectionId => $collection) {
-                if (($collection['class'] ?? '') !== Horde_ActiveSync::CLASS_TASKS) {
-                    continue;
-                }
-                $collBackendId = $collection['serverid'] ?? '';
-                if ($collBackendId === $backendId
-                    || $collectionId === $backendId
-                    || $collectionId === $tasklistId) {
-                    $cache->removeCollection($collectionId, true);
-                    $deviceUpdated = true;
-                }
+            if (self::_purgeActiveSyncTaskListCollections($cache, $tasklistId)) {
+                $deviceUpdated = true;
             }
 
             if ($deviceUpdated) {
                 $cache->save();
+                $updated = true;
+            }
+        }
+
+        return $updated;
+    }
+
+    /**
+     * @param Horde_ActiveSync_SyncCache $cache
+     * @param string $tasklistId
+     *
+     * @return boolean
+     */
+    protected static function _purgeActiveSyncTaskListCollections(
+        Horde_ActiveSync_SyncCache $cache,
+        $tasklistId
+    ) {
+        $backendId = Horde_ActiveSync::CLASS_TASKS . ':' . $tasklistId;
+        $updated = false;
+
+        foreach ($cache->getCollections(false) as $collectionId => $collection) {
+            if (($collection['class'] ?? '') !== Horde_ActiveSync::CLASS_TASKS) {
+                continue;
+            }
+            $collBackendId = $collection['serverid'] ?? '';
+            if ($collBackendId === $backendId
+                || $collectionId === $backendId
+                || $collectionId === $tasklistId) {
+                $cache->removeCollection($collectionId, true);
                 $updated = true;
             }
         }


### PR DESCRIPTION
# Nag: ActiveSync task lists (separate folders, web ↔ mobile device)

## Summary

Nag supports **web-side create / update / delete of task lists** when ActiveSync runs with **separate task folders** (`activesync_no_multiplex`). List changes update preferences, invalidate folder hierarchy in the device cache, and rely on the ActiveSync mobile device to run **FolderSync** (`FolderHierarchy:Add` / `Remove`) before item-level **SYNC** on `Tasks:<share-id>`.

Companion changes in **Horde ActiveSync** (`Ping.php`, `Collections.php`) are documented in a separate PR; this document covers **Nag only**.

---

## Background: two layers of sync

With `activesync_no_multiplex` enabled, each synced task list is exposed as its own ActiveSync folder:

| Layer | Protocol | What moves |
|-------|----------|------------|
| **Folder hierarchy** | FolderSync | Which task lists exist (Add / Update / Remove) |
| **Items** | SYNC on `Tasks:<share-id>` | Tasks inside one list |

Important constraints:

1. **`sync_lists` preference** — Nag only exposes lists selected here to ActiveSync (`Nag_Api::sources(..., $sync_only = true)`). The default list is always included via prefs logic.
2. **No server push for new folders** — After a web-side list change, the device must run **FolderSync**; there is no out-of-band notification that creates folders on the mobile device.
3. **Separate PHP sessions** — Web UI and `activesync.php` do not share in-memory prefs; writes must hit storage immediately (`persistPrefs()`).
4. **Device cache vs DB state** — Per device, Horde keeps a **sync cache** (folder UIDs, collection synckeys, hierarchy key) and **foldersync / collection state** in the database. These must stay consistent; aggressive cache wipes cause KEYMISMATCH, full resets, and broken PING.

---

## Problem

With separate task folders enabled, web-side **create**, **update**, and **delete** of task lists must propagate to ActiveSync mobile devices. List CRUD must update `sync_lists`, persist preferences for the next sync request, invalidate folder hierarchy on registered devices, and update the per-device sync cache without breaking foldersync state or PING.

This PR implements that workflow for Nag list CRUD and for manual `sync_lists` preference changes.

## Design constraints

Cache and preference handling follow these rules:

| Rule | Rationale |
|------|-----------|
| **Notify** via `hierarchy = '0'` only | Forces FolderSync on the next device request without deleting stored foldersync state |
| **Do not** clear foldersync DB state on list add | Avoids synckey mismatch (KEYMISMATCH) and full device folder cache reset |
| **Do not** prune folder cache in `notifyActiveSyncOfTaskListChange()` | Folder UIDs must remain until FolderSync delivers `FolderHierarchy:Remove` |
| **On web delete**, remove **collections** only | Stops PING/SYNC on removed lists while folder mappings stay for FolderSync Remove |
| **Prune** only from `sync_lists` `on_change` | User-driven shrink of synced lists; allowlist is `array_values(getSyncLists())` (share ids, not numeric array keys) |
| **`persistPrefs()`** after web writes | Web UI and `activesync.php` use separate sessions; prefs must be stored before the next sync request |
| **List all devices** for auth + original user id | Device rows may be registered under either Horde id; both must be updated |

---

## Solution overview

```mermaid
sequenceDiagram
    participant Web as Nag web UI
    participant Nag as Nag.php
    participant Prefs as DB prefs
    participant Cache as Device sync cache
    participant Device as ActiveSync mobile device

    Web->>Nag: addTasklist / updateTasklist / deleteTasklist
    Nag->>Prefs: sync_lists, display_tasklists (persistPrefs)
    Nag->>Nag: expireListCache (shares)
    alt delete
        Nag->>Cache: remove collections only (keep folder mapping)
    end
    Nag->>Cache: hierarchy = 0, bump timestamp
    Device->>Cache: FolderSync
    Cache-->>Device: FolderHierarchy Add/Remove
    Device->>Cache: SYNC per Tasks:share-id
```

**Behaviour:**

| Event | Nag actions |
|-------|-------------|
| **Create** (web or API with `synchronize`) | Add to `sync_lists`, `persistPrefs`, invalidate hierarchy |
| **Update** | `persistPrefs`, invalidate hierarchy |
| **Delete** | Update prefs, remove collections from device cache, invalidate hierarchy; keep folder cache until FolderSync Remove |
| **`sync_lists` pref change** | `pruneActiveSyncTaskCache()`, `touchActiveSyncDeviceCaches()` |

---

## File-by-file changes

### `lib/Nag.php`

Central implementation. New and changed behaviour:

#### Task list CRUD hooks

| Method | Change |
|--------|--------|
| `addTasklist($info, $display, $sync)` | Third parameter `$sync`: when true, adds share id to `sync_lists` and calls `notifyActiveSyncOfTaskListChange()`. Web create uses `$sync = true`. |
| `updateTasklist()` | Calls `notifyActiveSyncOfTaskListChange()` after save (rename/color/description → folder **Update** on next FolderSync). |
| `deleteTasklist()` | Removes list from `display_tasklists` and `sync_lists`, deletes share/storage, then **`removeActiveSyncTaskListCollectionsFromDeviceCache()`** (collections only), then **`notifyActiveSyncOfTaskListChange()`**. Does **not** remove folder mappings from device cache. |

#### Session and prefs

| Method | Purpose |
|--------|---------|
| `refreshWebSessionState()` | Called from `initialize()`: reloads prefs from storage and expires `nag_shares` list cache so the web UI sees current data after external changes. |
| `persistPrefs()` | `$GLOBALS['prefs']->store()` — required so ActiveSync requests see web-written `sync_lists` immediately. |
| `addTasklistToDisplayListsPref()` / `removeTasklistFromDisplayListsPref()` | Maintain `display_tasklists` without duplicate entries; mirror updates in `$GLOBALS['display_tasklists']` when set. |
| `addTasklistToSyncLists()` / `removeTasklistFromSyncLists()` | Maintain serialized `sync_lists` via `_getPrefList` / `_setPrefList`. |
| `getSyncLists()` | Returns share ids from pref, filtered to lists that still exist; falls back to default editable list. Drives ActiveSync folder list via `Nag_Api::sources(..., true)`. |

#### ActiveSync notification and cache management

| Method | Purpose |
|--------|---------|
| `notifyActiveSyncOfTaskListChange()` | `persistPrefs()`, expire share cache, **`requestActiveSyncFolderHierarchySync()`** only — **no** `pruneActiveSyncTaskCache()` here. Optional user notification in Nag UI. |
| `requestActiveSyncFolderHierarchySync()` | For each device with non-empty cache: set **`hierarchy = '0'`**, `updateTimestamp()`, `save()`. Skips devices with empty folder/collection cache. Requires `activesync_no_multiplex`. Does **not** delete foldersync rows in SQL. |
| `removeActiveSyncTaskListCollectionsFromDeviceCache($tasklistId)` | **New.** Removes SYNC/PING **collection** entries for `Tasks:<id>` on all user devices; **folders** stay for FolderSync Remove. Used from `deleteTasklist()`. |
| `removeActiveSyncTaskListFromDeviceCache($tasklistId)` | Full cleanup (folders + collections). **Not** used on web delete; reserved for exceptional/manual repair. |
| `_purgeActiveSyncTaskListCollections($cache, $tasklistId)` | Shared helper: `removeCollection($id, true)` for matching task collections. |
| `pruneActiveSyncTaskCache($allowedShareIds = null)` | Removes folder/collection cache entries **not** in allowlist. Default allowlist: **`array_values(self::getSyncLists())`** (share ids → `Tasks:<id>`). Used from prefs `on_change` only. |
| `touchActiveSyncDeviceCaches()` | Bumps cache timestamp on all devices (wakes stale PING / concurrent sync detection). Used after prefs `sync_lists` change. |
| `_isActiveSyncEnabled()` | Checks `$GLOBALS['conf']['activesync']['enabled']`. |
| `_listActiveSyncDevicesForUser()` | Merges `listDevices()` for auth id and `getAuth('original')`; deduplicates by `device_id` + `device_user`. |

---

### `lib/Api.php`

| Area | Change |
|------|--------|
| `addTasklist(..., $params)` | Documents and passes **`synchronize`** parameter to `Nag::addTasklist(..., true, !empty($params['synchronize']))`. ActiveSync / RPC callers that create a list with `synchronize => true` add it to `sync_lists` and trigger hierarchy invalidation — same as web create. |
| `sources($writeable, $sync_only)` | When `$sync_only` is true, intersects task lists with **`Nag::getSyncLists()`**. This is how the ActiveSync connector builds the server folder list for FolderSync diffs. |

No change to delete/update API surface beyond delegating to `Nag::updateTasklist` / share layer; delete goes through shares/forms calling `Nag::deleteTasklist`.

---

### `lib/Form/CreateTaskList.php`

`execute()` calls:

```php
return Nag::addTasklist($info, true, true);
```

- Second argument: add to **display** lists.
- Third argument: add to **sync_lists** and **notify ActiveSync**.

Ensures a task list created in the web UI is synced to the ActiveSync mobile device without a separate prefs step.

---

### `lib/Form/DeleteTaskList.php`

Unchanged call path: `Nag::deleteTasklist($this->_tasklist)`. Documented here because it is the **web delete entry point** that triggers collection cleanup + hierarchy invalidation described above.

---

### `config/prefs.php`

| Setting | Role |
|---------|------|
| `sync_lists` | Multi-select of extra task lists to sync (plus default). **`on_change`**: ensures default list remains selected; if ActiveSync + `activesync_no_multiplex`, runs **`Nag::pruneActiveSyncTaskCache()`** and **`Nag::touchActiveSyncDeviceCaches()`** with user notification. This is the **only** supported path for shrinking the cached folder set when the user removes lists from sync in prefs UI. |
| `activesync_no_multiplex` | Checkbox “Support separate task lists?” — must be enabled for per-list folders and for all Nag ActiveSync cache helpers in this PR. |

Prefs group `activesync` includes both members for the Nag preferences screen.

---

## What is intentionally *not* in this PR

| Topic | Where |
|-------|--------|
| PING requires FolderSync when hierarchy key missing | ActiveSync `Ping.php` |
| Orphan collection cleanup on PING (`StateGone`) | ActiveSync `Collections.php` |
| Horde Core connector multiplex checks | `Horde_Core_ActiveSync_Connector` (existing) |

Enable **`activesync_no_multiplex`** in Nag prefs and select lists under **`sync_lists`** before testing separate folders.

---

## Test plan

- [ ] **Web create** — New list appears in Nag; `sync_lists` contains share id; after the mobile device syncs, new task folder appears; tasks sync into it.
- [ ] **Web rename / color** — Folder **Update** on device after FolderSync.
- [ ] **Web delete** — List gone in Nag; device receives **Remove** on FolderSync; no endless PING for old folder UID; tasks in that folder gone on device.
- [ ] **Prefs: remove list from sync_lists** — Prune drops extra cached folders; FolderSync removes folders not in allowlist.
- [ ] **Mobile device create** (if supported) — `addTasklist(..., synchronize => true)` adds to `sync_lists` and invalidates hierarchy.
- [ ] **Logs** — No `KEYMISMATCH` on web add; stable PING after delete when deployed together with the ActiveSync companion PR.

---

## Deployment

- Apply together with the **Horde ActiveSync** companion PR (`Ping.php`, `Collections.php`) for hierarchy checks and orphan collection handling during PING.
- **Rename via web** updates share metadata and invalidates hierarchy; client behaviour for folder **Update** depends on the mobile ActiveSync implementation.
- Stale entries in serialized `sync_lists` for deleted shares are filtered by `getSyncLists()` at runtime; saving prefs rewrites the stored list.

---

## Related configuration

```text
Nag preferences → ActiveSync:
  ☑ Support separate task lists?  (activesync_no_multiplex)
  Select sync_lists …
```

Horde-wide: `$conf['activesync']['enabled']` must be true.
