### PR TITLE
fix(security): restrict unserialize allowed_classes (ZDI-20-1051)

### DIFF
--- a/lib/Driver/Sql.php
+++ b/lib/Driver/Sql.php
@@ -719,7 +719,7 @@ class Nag_Driver_Sql extends Nag_Driver
                 ?? null,
             'alarm' => $row['task_alarm'],
             'methods' => Horde_String::convertCharset(
-                @unserialize($row['task_alarm_methods']),
+                @unserialize($row['task_alarm_methods'], ['allowed_classes' => false]),
                 $this->_params['charset'],
                 'UTF-8'
             ),

--- a/lib/Nag.php
+++ b/lib/Nag.php
@@ -251,7 +251,7 @@ class Nag
         $tasks->process();
 
         if ($options['external']
-            && ($apps = @unserialize($prefs->getValue('show_external')))
+            && ($apps = @unserialize($prefs->getValue('show_external'), ['allowed_classes' => false]))
             && is_array($apps)) {
             foreach ($apps as $app) {
                 // We look for registered apis that support listAs(taskHash).
@@ -510,7 +510,7 @@ class Nag
             return $tasklists;
         }
 
-        $display_tasklists = @unserialize($GLOBALS['prefs']->getValue('display_tasklists'));
+        $display_tasklists = @unserialize($GLOBALS['prefs']->getValue('display_tasklists'), ['allowed_classes' => false]);
         if (is_array($display_tasklists)) {
             foreach ($display_tasklists as $id) {
                 try {
@@ -2151,7 +2151,7 @@ class Nag
      *
      * @throws Horde_ActiveSync_Exception
      */
-    public static function pruneActiveSyncTaskCache(array $allowedShareIds = null)
+    public static function pruneActiveSyncTaskCache(?array $allowedShareIds = null)
     {
         if (!self::_isActiveSyncEnabled()
             || !$GLOBALS['prefs']->getValue('activesync_no_multiplex')) {
@@ -2278,7 +2278,7 @@ class Nag
      */
     protected static function _getPrefList($pref)
     {
-        $list = @unserialize($GLOBALS['prefs']->getValue($pref));
+        $list = @unserialize($GLOBALS['prefs']->getValue($pref), ['allowed_classes' => false]);
 
         return is_array($list) ? array_values($list) : [];
     }

--- a/lib/Task.php
+++ b/lib/Task.php
@@ -1297,7 +1297,7 @@ class Nag_Task
             $prefs = $GLOBALS['prefs'];
         }
 
-        $methods = !empty($this->methods) ? $this->methods : @unserialize($prefs->getValue('task_alarms'));
+        $methods = !empty($this->methods) ? $this->methods : @unserialize($prefs->getValue('task_alarms'), ['allowed_classes' => false]);
         if (!$methods) {
             $methods = [];
         }

--- a/lib/View/List.php
+++ b/lib/View/List.php
@@ -131,7 +131,7 @@ class Nag_View_List
         $view->sortdir = $prefs->getValue('sortdir');
         $view->sortdirclass = $view->sortdir ? 'sortup' : 'sortdown';
         $view->dateFormat = $prefs->getValue('date_format');
-        $view->columns = @unserialize($prefs->getValue('tasklist_columns'));
+        $view->columns = @unserialize($prefs->getValue('tasklist_columns'), ['allowed_classes' => false]);
         $view->smartShare = $this->_smartShare;
         $view->haveSearch = $this->_haveSearch;
         $view->tab_name = $this->_vars->get('tab_name', $prefs->getValue('show_completed'));


### PR DESCRIPTION
## Summary

- Follow-up to horde/imp#7
- All bare `@unserialize()` calls on prefs/DB data now pass `['allowed_classes' => false]` to prevent object instantiation from untrusted serialized data
- Affected preferences: `tasklist_columns`, `task_alarms`, `show_external`, `display_tasklists`, and the generic `_getPrefList()` helper
- Affected DB column: `task_alarm_methods` in the SQL driver