### PR TITLE
Refactor task retrieval logic in Sql.php

### DIFF
--- a/lib/Driver/Sql.php
+++ b/lib/Driver/Sql.php
@@ -79,7 +79,8 @@ class Nag_Driver_Sql extends Nag_Driver
         }
         if (empty($task)) {
             $readable_lists = Nag::listTasklists();
-            foreach ($results as $row) {
+            $results->reset();
+            while ($row = $results->each()) {
                 if (isset($readable_lists[$row->tasklist])) {
                     $task = $row;
                     break;
@@ -135,8 +136,15 @@ class Nag_Driver_Sql extends Nag_Driver
         }
 
         if (!is_array($taskIds)) {
-            $results = new Nag_Task($this, $this->_buildTask(reset($rows)));
-            $this->_tasklist = $results->tasklist;
+            if (count($rows) === 1) {
+                $results = new Nag_Task($this, $this->_buildTask(reset($rows)));
+                $this->_tasklist = $results->tasklist;
+            } else {
+                $results = new Nag_Task();
+                foreach ($rows as $row) {
+                    $results->add(new Nag_Task($this, $this->_buildTask($row)));
+                }
+            }
         } else {
             $results = new Nag_Task();
             foreach ($rows as $row) {


### PR DESCRIPTION
# Fix `getByUID()` task iteration in Nag SQL driver

## Summary

Fixes PHP 8 warnings (`Attempt to read property "tasklist" on null/string/int/...`) in `Nag_Driver_Sql::getByUID()` when resolving a single task instance by UID (`$getall = false`).

## Problem

The fallback path that searches readable task lists used `foreach ($results as $row)`. `Nag_Task` is not iterable in that sense; `foreach` walks public object properties instead of child tasks. On PHP 8+, accessing `$row->tasklist` on those values triggers warnings and can break task lookup (e.g. during ActiveSync import/update).

When one UID exists in multiple task lists, `_getBy()` also returned only the first database row, so the owner/readable list selection could not see other instances.

## Solution

- Replace the second `foreach` with `reset()` + `each()`, matching the first loop in `getByUID()`.
- When a single UID query returns multiple rows, build a `Nag_Task` container with all instances (same pattern as multi-UID queries).

## Files changed

- `lib/Driver/Sql.php`

## Test plan

- [ ] Open Nag in the web UI; confirm task lists load without new warnings in `horde.log`.
- [ ] Trigger ActiveSync task sync (or import/update a task by UID) and verify no `tasklist on null` warnings from `Driver/Sql.php` line 83.
- [ ] If applicable: same UID in two task lists — confirm `getByUID($uid, null, false)` returns a task from an owned or readable list.
